### PR TITLE
左ペインメニューを読みやすくする

### DIFF
--- a/pages/chara-data-viewer.py
+++ b/pages/chara-data-viewer.py
@@ -149,14 +149,7 @@ class KoikatuCharaHeader:
 title = get_text("title", "ja")
 st.set_page_config(page_title=title)
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 

--- a/pages/convert-to-aicomi.py
+++ b/pages/convert-to-aicomi.py
@@ -35,14 +35,7 @@ def get_text(key, lang="ja"):
 title = get_text("title", "ja")
 st.set_page_config(page_title=title)
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 

--- a/pages/digital-craft-calligrapher.py
+++ b/pages/digital-craft-calligrapher.py
@@ -3526,14 +3526,7 @@ def main():
         title = get_text("title", "ja")
         st.set_page_config(page_title=title, page_icon="✨", layout="wide")
 
-        # サイドバーに言語選択を配置
-        with st.sidebar:
-            lang = st.selectbox(
-                "Language / 言語",
-                options=["ja", "en"],
-                format_func=lambda x: "日本語" if x == "ja" else "English",
-                index=0,
-            )
+        lang = st.session_state.get("lang", "ja")
 
         st.title(f"✨ {get_text('title', lang)}")
         st.markdown(get_text("subtitle", lang))

--- a/pages/digital-craft-character-converter.py
+++ b/pages/digital-craft-character-converter.py
@@ -54,7 +54,7 @@ TRANSLATIONS = {
         "failed_table_title": "変換失敗一覧",
     },
     "en": {
-        "title": "Digital Craft Character Unifier",
+        "title": "Digital Craft Unified Chara Converter",
         "subtitle": "Unify all characters in a scene to Honeycome / Summer Vacation Scramble / Aicomi in one batch, greatly reducing the effort of replacing characters.",
         "usage_title": "How to use",
         "usage_content": """
@@ -725,13 +725,7 @@ def main() -> None:
     page_title = get_text("title", "ja")
     st.set_page_config(page_title=page_title, page_icon=":arrows_counterclockwise:")
 
-    with st.sidebar:
-        lang = st.selectbox(
-            "Language / 言語",
-            options=["ja", "en"],
-            format_func=lambda x: "日本語" if x == "ja" else "English",
-            index=0,
-        )
+    lang = st.session_state.get("lang", "ja")
 
     st.title(get_text("title", lang))
     st.write(get_text("subtitle", lang))

--- a/pages/digital-craft-data-viewer.py
+++ b/pages/digital-craft-data-viewer.py
@@ -520,14 +520,7 @@ def get_top_level_folders(hs):
 title = get_text("title", "ja")
 st.set_page_config(page_title=title, page_icon=":bar_chart:")
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 st.markdown(get_text("description", lang))

--- a/pages/digital-craft-item-converter.py
+++ b/pages/digital-craft-item-converter.py
@@ -140,14 +140,7 @@ def get_text(key, lang="ja"):
 title = get_text("title", "ja")
 st.set_page_config(page_title=title, page_icon=":arrows_counterclockwise:")
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 st.write(get_text("subtitle", lang))

--- a/pages/ec-to-kk.py
+++ b/pages/ec-to-kk.py
@@ -607,14 +607,7 @@ def main():
     title = get_text("title", "ja")
     st.set_page_config(page_title=title)
 
-    # サイドバーに言語選択を配置
-    with st.sidebar:
-        lang = st.selectbox(
-            "Language / 言語",
-            options=["ja", "en"],
-            format_func=lambda x: "日本語" if x == "ja" else "English",
-            index=0,
-        )
+    lang = st.session_state.get("lang", "ja")
 
     st.title(get_text("title", lang))
 

--- a/pages/home.py
+++ b/pages/home.py
@@ -1,0 +1,43 @@
+import streamlit as st
+
+TRANSLATIONS = {
+    "ja": {
+        "title": "kk-snippets",
+        "description": """
+illusion/ILLGAMESのゲームに関連するツールを置くページです。
+
+動作の不具合などあれば [@tropical_362827](https://twitter.com/tropical_362827) か [GitHub](https://github.com/great-majority/kk-snippets/issues) に送っていただけると助かります🙇
+
+←のメニューからページを選択してください。
+
+<a href="https://github.com/great-majority/kk-snippets">
+    <img src="https://opengraph.githubassets.com/24d9aa2fc57ba5cc9c57898c8c43138d09b4ed7e71ede99bbe892ec0b7de6ded/great-majority/kk-snippets" alt="githubリンク" width="80%">
+</a>
+""",
+    },
+    "en": {
+        "title": "kk-snippets",
+        "description": """
+A collection of tools related to illusion/ILLGAMES titles.
+
+If you find any bugs or strange translations, please let us know via [GitHub Issues](https://github.com/great-majority/kk-snippets/issues) or [@tropical_362827](https://twitter.com/tropical_362827).🙇
+
+Please select a page from the menu on the left.
+
+<a href="https://github.com/great-majority/kk-snippets">
+    <img src="https://opengraph.githubassets.com/24d9aa2fc57ba5cc9c57898c8c43138d09b4ed7e71ede99bbe892ec0b7de6ded/great-majority/kk-snippets" alt="GitHub link" width="80%">
+</a>
+""",
+    },
+}
+
+
+def get_text(key, lang="ja"):
+    return TRANSLATIONS.get(lang, TRANSLATIONS["ja"]).get(key, key)
+
+
+lang = st.session_state.get("lang", "ja")
+
+st.title(get_text("title", lang))
+
+st.markdown(get_text("description", lang), unsafe_allow_html=True)

--- a/pages/sv-chara-trait-editor.py
+++ b/pages/sv-chara-trait-editor.py
@@ -361,14 +361,7 @@ class SVSSaveData:
 title = get_text("title", "ja")
 st.set_page_config(page_title=title, layout="wide")
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 st.divider()

--- a/pages/sv-hc-converter.py
+++ b/pages/sv-hc-converter.py
@@ -12,7 +12,7 @@ from kkloader.KoikatuCharaData import BlockData
 
 TRANSLATIONS = {
     "ja": {
-        "title": "ILLGAMESキャラクターコンバータ",
+        "title": "ハニカムシリーズキャラクター変換ツール",
         "description": """
 ハニカム↔サマすく↔アイコミでキャラクターデータを相互変換するツールです。キャラデータ読み込み後、選択したタイトルへキャラ変換を行わうことができます。
 
@@ -53,7 +53,7 @@ TRANSLATIONS = {
         "language_selector": "言語 / Language",
     },
     "en": {
-        "title": "ILLGAMES Character Converter",
+        "title": "Honeycome Series Character Converter",
         "description": """
 This tool allows you to convert character data between Honey Come, Summer Vacation Scramble, and Aicomi. After loading character data, you can convert the character to the selected title.
 
@@ -642,14 +642,7 @@ def ac_to_sv(ac: AicomiCharaData) -> SummerVacationCharaData:
 title = get_text("title", "ja")
 st.set_page_config(page_title=title)
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 

--- a/pages/sv-stat.py
+++ b/pages/sv-stat.py
@@ -349,14 +349,7 @@ class SVSSaveData:
 title = get_text("title", "ja")
 st.set_page_config(page_title=title, layout="wide")
 
-# サイドバーに言語選択を配置
-with st.sidebar:
-    lang = st.selectbox(
-        "Language / 言語",
-        options=["ja", "en"],
-        format_func=lambda x: "日本語" if x == "ja" else "English",
-        index=0,
-    )
+lang = st.session_state.get("lang", "ja")
 
 st.title(get_text("title", lang))
 st.write(get_text("description", lang))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "kkloader==0.1.20",
-    "streamlit==1.51.0",
+    "streamlit>=1.55.0",
     "pyvis==0.3.2",
     "networkx==3.3",
     "scipy==1.15.3",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,59 +1,85 @@
 import streamlit as st
 
-# ========================================
-# i18n対応: 多言語辞書
-# ========================================
+st.set_page_config(page_title="kk-snippets", layout="wide")
 
-TRANSLATIONS = {
+NAV_TITLES = {
     "ja": {
-        "title": "kk-snippets",
-        "description": """
-illusion/ILLGAMESのゲームに関連するツールを置くページです。
-
-動作の不具合などあれば [@tropical_362827](https://twitter.com/tropical_362827) か [GitHub](https://github.com/great-majority/kk-snippets/issues) に送っていただけると助かります🙇
-
-←のメニューからページを選択してください。
-
-<a href="https://github.com/great-majority/kk-snippets">
-    <img src="https://opengraph.githubassets.com/24d9aa2fc57ba5cc9c57898c8c43138d09b4ed7e71ede99bbe892ec0b7de6ded/great-majority/kk-snippets" alt="githubリンク" width="80%">
-</a>
-""",
+        "home": "ホーム",
+        "sec_koikatsu": "コイカツ関連",
+        "sec_honeycomb": "ハニカム関連",
+        "sec_digcraft": "デジクラ関連",
+        "sec_common": "共通ツール",
+        "ec_to_kk": "コイカツシリーズキャラクター変換ツール",
+        "sv_hc_converter": "ハニカムシリーズキャラクター変換ツール",
+        "sv_chara_trait_editor": "サマすくキャラ特性エディター",
+        "sv_stat": "サマすく行動ログビューア",
+        "dc_calligrapher": "デジクラカリグラファー",
+        "dc_chara_converter": "デジクラキャラクター統一コンバータ",
+        "dc_data_viewer": "デジクラシーンデータビューア",
+        "dc_item_converter": "デジクラ基本形アイテム変換ツール",
+        "chara_data_viewer": "illusion/ILLGAMESキャラ情報表示",
     },
     "en": {
-        "title": "kk-snippets",
-        "description": """
-A collection of tools related to illusion/ILLGAMES titles.
-
-If you find any bugs or strange translations, please let us know via [GitHub Issues](https://github.com/great-majority/kk-snippets/issues) or [@tropical_362827](https://twitter.com/tropical_362827).🙇
-
-Please select a page from the menu on the left.
-
-<a href="https://github.com/great-majority/kk-snippets">
-    <img src="https://opengraph.githubassets.com/24d9aa2fc57ba5cc9c57898c8c43138d09b4ed7e71ede99bbe892ec0b7de6ded/great-majority/kk-snippets" alt="GitHub link" width="80%">
-</a>
-""",
+        "home": "Home",
+        "sec_koikatsu": "Koikatsu",
+        "sec_honeycomb": "Honeycome",
+        "sec_digcraft": "Digital Craft",
+        "sec_common": "Common Tools",
+        "ec_to_kk": "Koikatsu Character Data Converter",
+        "sv_hc_converter": "Honeycome Series Character Converter",
+        "sv_chara_trait_editor": "Summer Vacation Scramble Trait Editor",
+        "sv_stat": "Summer Vacation Scramble Action Log Viewer",
+        "dc_calligrapher": "Digital Craft Calligrapher",
+        "dc_chara_converter": "Digital Craft Character Converter",
+        "dc_data_viewer": "Digital Craft Scene Data Viewer",
+        "dc_item_converter": "Digital Craft Primitive Item Converter",
+        "chara_data_viewer": "illusion/ILLGAMES Character Data Viewer",
     },
 }
 
-
-def get_text(key, lang="ja"):
-    """指定した言語のテキストを取得"""
-    return TRANSLATIONS.get(lang, TRANSLATIONS["ja"]).get(key, key)
-
-
-# ページ設定とタイトル
-title = get_text("title", "ja")
-st.set_page_config(page_title=title)
-
-# サイドバーに言語選択を配置
 with st.sidebar:
     lang = st.selectbox(
         "Language / 言語",
         options=["ja", "en"],
         format_func=lambda x: "日本語" if x == "ja" else "English",
         index=0,
+        key="lang",
     )
 
-st.title(get_text("title", lang))
+t = NAV_TITLES.get(lang, NAV_TITLES["ja"])
 
-st.markdown(get_text("description", lang), unsafe_allow_html=True)
+pg = st.navigation(
+    {
+        "": [
+            st.Page("pages/home.py", title=t["home"], default=True),
+            st.Page(
+                "pages/convert-to-aicomi.py",
+                title="convert-to-aicomi",
+                visibility="hidden",
+            ),  # type: ignore[call-arg]
+        ],
+        t["sec_koikatsu"]: [
+            st.Page("pages/ec-to-kk.py", title=t["ec_to_kk"]),
+        ],
+        t["sec_honeycomb"]: [
+            st.Page("pages/sv-hc-converter.py", title=t["sv_hc_converter"]),
+            st.Page("pages/sv-chara-trait-editor.py", title=t["sv_chara_trait_editor"]),
+            st.Page("pages/sv-stat.py", title=t["sv_stat"]),
+        ],
+        t["sec_digcraft"]: [
+            st.Page("pages/digital-craft-calligrapher.py", title=t["dc_calligrapher"]),
+            st.Page(
+                "pages/digital-craft-character-converter.py",
+                title=t["dc_chara_converter"],
+            ),
+            st.Page("pages/digital-craft-data-viewer.py", title=t["dc_data_viewer"]),
+            st.Page(
+                "pages/digital-craft-item-converter.py", title=t["dc_item_converter"]
+            ),
+        ],
+        t["sec_common"]: [
+            st.Page("pages/chara-data-viewer.py", title=t["chara_data_viewer"]),
+        ],
+    }
+)
+pg.run()

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ requires-dist = [
     { name = "pyvis", specifier = "==0.3.2" },
     { name = "scipy", specifier = "==1.15.3" },
     { name = "skia-pathops", specifier = "==0.9.2" },
-    { name = "streamlit", specifier = "==1.51.0" },
+    { name = "streamlit", specifier = ">=1.55.0" },
     { name = "svgelements", specifier = "==1.9.6" },
     { name = "wildmeshing", specifier = "==0.4.1" },
 ]
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "streamlit"
-version = "1.51.0"
+version = "1.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altair" },
@@ -1294,9 +1294,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog", marker = "sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/6d/327ddd5fc35fcf2aeecb4040668337f5565a1c6c95b1e892b8bfd4bb9031/streamlit-1.51.0.tar.gz", hash = "sha256:1e742a9c0b698f466c6f5bf58d333beda5a1fbe8de660743976791b5c1446ef6", size = 9742904, upload_time = "2025-10-29T17:07:39.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/85/7c669b3a1336d34ef39fa9760fbd343185f3b15db2ad0838fd78423d1c7f/streamlit-1.56.0.tar.gz", hash = "sha256:1176acfa89ae1318b79078e8efe689a9d02e8d58e325c00fc0e55fa2f3fe8d6a", size = 8559239, upload_time = "2026-03-31T22:29:38.59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/60/868371b6482ccd9ef423c6f62650066cf8271fdb2ee84f192695ad6b7a96/streamlit-1.51.0-py3-none-any.whl", hash = "sha256:4008b029f71401ce54946bb09a6a3e36f4f7652cbb48db701224557738cfda38", size = 10171702, upload_time = "2025-10-29T17:07:35.97Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/91/cb6f13a89e376ef179309d74f37a70ea0041d5e4b5ba5c4836dbf6e020ad/streamlit-1.56.0-py3-none-any.whl", hash = "sha256:8677a335734a30a51bc57ad0ec910e365d95f7c456fc02c60032927cd0729dc5", size = 9052089, upload_time = "2026-03-31T22:29:36.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 機能が増えすぎてファイル名だとムリがあるように思えたので、カテゴリ分けとページ名を加え読みやすくしてみた
- `st.Page()` に `visibility="hidden"` できるようになったのは[一月前らしい](https://github.com/streamlit/streamlit/pull/13905)

<img width="355" height="517" alt="スクリーンショット 2026-04-05 19 36 29" src="https://github.com/user-attachments/assets/c1756602-f8a9-4e1f-a805-5abad74fc69c" />
