### PR TITLE
メモリ上限を超えそうなパターンにハードリミットを設ける

### DIFF
--- a/pages/chara-data-viewer.py
+++ b/pages/chara-data-viewer.py
@@ -58,6 +58,7 @@ illusion/ILLGAMESのキャラ画像に含まれている色々なデータを一
 """,
         "file_uploader": "コイカツ/サマすく/ハニカムのキャラ画像を選択",
         "error_load": "ファイルの読み込みに失敗しました。未対応のファイルです。",
+        "error_corrupted_header": "ファイルのヘッダが破損しています。別のファイルを試してください。",
         "success_load": "正常にデータを読み込めました。",
         "error_unsupported": "このヘッダのファイルには対応していません:",
         "card_image_caption": "カード画像",
@@ -98,6 +99,7 @@ Please consider the following as a reference only.
 """,
         "file_uploader": "Select a character image (Koikatsu/Summer Vacation/Honey Come)",
         "error_load": "Failed to load file. Unsupported file format.",
+        "error_corrupted_header": "The file header is corrupted. Please try a different file.",
         "success_load": "Data loaded successfully.",
         "error_unsupported": "This header file is not supported:",
         "card_image_caption": "Card image",
@@ -171,7 +173,11 @@ if file is not None:
 
     st.success(get_text("success_load", lang), icon="✅")
 
-    header = kch.header.decode("utf-8")
+    try:
+        header = kch.header.decode("utf-8")
+    except UnicodeDecodeError:
+        st.error(get_text("error_corrupted_header", lang), icon="🚨")
+        st.stop()
     st.write(header)
 
     match header:

--- a/pages/digital-craft-calligrapher.py
+++ b/pages/digital-craft-calligrapher.py
@@ -147,6 +147,7 @@ TRANSLATIONS = {
         "error_no_text": "テキストが入力されていません",
         "generating": "シーンを生成中...",
         "success_generate": "生成完了！ ({count} 個の平面)",
+        "dot_plane_limit_error": "推定平面数が上限を超えています。推定 {count:,} 個 / 上限 {limit:,} 個。文字数を減らすか、一文字あたり細かさを下げるか、アンチエイリアスをOFFにして平面結合をONにしてください。",
         "preview_title": "文字生成イメージ",
         "original_image": "元のテキスト画像",
         "pixel_data": "ピクセルデータ ({width}×{height})",
@@ -289,6 +290,7 @@ I wrote a blog post explaining it [here](https://qiita.com/tropical-362827/items
         "error_no_text": "No text entered",
         "generating": "Generating scene...",
         "success_generate": "Generation complete! ({count} planes)",
+        "dot_plane_limit_error": "Estimated plane count exceeds the limit. Estimated {count:,} / limit {limit:,}. Reduce the text length or resolution, or turn antialiasing off and enable plane merging.",
         "preview_title": "Text generation preview",
         "original_image": "Original text image",
         "pixel_data": "Pixel data ({width}×{height})",
@@ -323,6 +325,7 @@ class DotRenderConfig:
     FONT_SIZE = 200
     CHAR_CANVAS_PADDING = 5
     DEFAULT_RESOLUTION = 100
+    MAX_PLANE_COUNT = 60_000
 
 
 class MeshRenderConfig:
@@ -1411,6 +1414,157 @@ class DotRenderPipeline:
         return planes, len(runs)
 
     @staticmethod
+    def count_planes_from_pixels(
+        pixels,
+        color=None,
+        edge_color=None,
+        antialias=True,
+        merge_horizontal=False,
+        merge_color_threshold=0.05,
+    ):
+        """平面オブジェクトを作らず、pixels_to_planes と同じ規則で平面数を数える。"""
+        height, width = pixels.shape
+        runs = []
+        runs_by_row = [[] for _ in range(height)]
+        if color is None:
+            color = {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0}
+        if edge_color is None:
+            edge_color = {"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0}
+
+        effective_threshold = 1 if antialias else 128
+
+        def flush_run(run_start, run_end, run_color, row_index):
+            run_info = {
+                "start": run_start,
+                "end": run_end,
+                "row": row_index,
+                "color": run_color,
+            }
+            runs.append(run_info)
+            runs_by_row[row_index].append(run_info)
+
+        for row in range(height):
+            run_start = None
+            run_color = None
+            run_end = None
+
+            for col in range(width):
+                pixel_value = pixels[row, col]
+                if pixel_value >= effective_threshold:
+                    shaded_color = DotRenderPipeline.resolve_pixel_color(
+                        pixel_value, color, edge_color, antialias
+                    )
+                    if run_start is None:
+                        run_start = col
+                        run_end = col
+                        run_color = shaded_color
+                    elif merge_horizontal and DotRenderPipeline.colors_close(
+                        shaded_color, run_color, merge_color_threshold
+                    ):
+                        run_end = col
+                    else:
+                        flush_run(run_start, run_end, run_color, row)
+                        run_start = col
+                        run_end = col
+                        run_color = shaded_color
+                elif run_start is not None:
+                    flush_run(run_start, run_end, run_color, row)
+                    run_start = None
+                    run_end = None
+                    run_color = None
+
+            if run_start is not None:
+                flush_run(run_start, run_end, run_color, row)
+
+        if not merge_horizontal:
+            return len(runs), len(runs)
+
+        def color_key(color_value):
+            return (
+                color_value["r"],
+                color_value["g"],
+                color_value["b"],
+                color_value["a"],
+            )
+
+        plane_count = 0
+        active_runs = {}
+        for row in range(height):
+            row_runs = runs_by_row[row]
+            next_active = {}
+            for run in row_runs:
+                key = (run["start"], run["end"], color_key(run["color"]))
+                if key in active_runs and active_runs[key]["row_end"] == row - 1:
+                    active_runs[key]["row_end"] = row
+                    next_active[key] = active_runs[key]
+                else:
+                    next_active[key] = {
+                        "start": run["start"],
+                        "end": run["end"],
+                        "color": run["color"],
+                        "row_start": row,
+                        "row_end": row,
+                    }
+
+            for key in active_runs:
+                if key not in next_active:
+                    plane_count += 1
+            active_runs = next_active
+
+        plane_count += len(active_runs)
+        return plane_count, len(runs)
+
+    @staticmethod
+    def estimate_plane_counts(
+        text,
+        font_size,
+        per_char_resolution,
+        color=None,
+        edge_color=None,
+        antialias=True,
+        font_path=None,
+        merge_horizontal=False,
+        merge_color_threshold=0.05,
+    ):
+        """ドットモード生成前に最終平面数を見積もる。"""
+        font = load_font(font_size, font_path)
+        canvas_width, canvas_height = DotRenderPipeline.compute_canvas_size(
+            text, font, DotRenderConfig.CHAR_CANVAS_PADDING
+        )
+        effective_threshold = 1 if antialias else 128
+        char_pixels_list, _, raw_plane_count = DotRenderPipeline.build_char_pixels(
+            text,
+            font,
+            font_size,
+            per_char_resolution,
+            canvas_width,
+            canvas_height,
+            effective_threshold,
+        )
+
+        plane_count = 0
+        plane_count_horizontal = 0
+        for char_pixels in char_pixels_list:
+            char_plane_count, char_horizontal_count = (
+                DotRenderPipeline.count_planes_from_pixels(
+                    np.fliplr(char_pixels),
+                    color=color,
+                    edge_color=edge_color,
+                    antialias=antialias,
+                    merge_horizontal=merge_horizontal,
+                    merge_color_threshold=merge_color_threshold,
+                )
+            )
+            plane_count += char_plane_count
+            plane_count_horizontal += char_horizontal_count
+
+        return {
+            "plane_count": plane_count,
+            "plane_count_horizontal": plane_count_horizontal,
+            "raw_plane_count": raw_plane_count,
+        }
+
+    @staticmethod
     def generate_text_scene(
         text,
         template_scene,
@@ -1645,6 +1799,26 @@ class DotRenderPipeline:
         lang,
     ):
         edge_color = hex_to_color(dot_settings["edge_color_hex"])
+        plane_count_estimate = DotRenderPipeline.estimate_plane_counts(
+            text=text_input,
+            font_size=font_size,
+            per_char_resolution=layout["grid_height"],
+            color=color,
+            edge_color=edge_color,
+            antialias=dot_settings["antialias"],
+            font_path=selected_font,
+            merge_horizontal=dot_settings["merge_horizontal"],
+            merge_color_threshold=dot_settings["merge_color_threshold"],
+        )
+        if plane_count_estimate["plane_count"] > DotRenderConfig.MAX_PLANE_COUNT:
+            st.error(
+                get_text("dot_plane_limit_error", lang).format(
+                    count=plane_count_estimate["plane_count"],
+                    limit=DotRenderConfig.MAX_PLANE_COUNT,
+                )
+            )
+            st.stop()
+
         with st.spinner(get_text("generating", lang)):
             (
                 scene,

--- a/pages/digital-craft-data-viewer.py
+++ b/pages/digital-craft-data-viewer.py
@@ -23,6 +23,7 @@ TRANSLATIONS = {
         "file_uploader_help": "デジタルクラフトのシーンデータ（.png）をアップロードしてください",
         "success_load": "シーンデータを読み込みました",
         "error_load": "ファイルの読み込みに失敗しました。シーンデータではない可能性があります。",
+        "error_corrupted_header": "ファイルのヘッダが破損しています。",
         "info_upload": "シーンデータ（.png）をアップロードしてください。",
         "scene_info_title": "シーン情報",
         "scene_title": "タイトル",
@@ -81,6 +82,7 @@ A tool to display and aggregate information contained in Digital Craft/Honey Com
         "file_uploader_help": "Please upload a Digital Craft/Honey Come scene data (.png)",
         "success_load": "Scene data loaded successfully",
         "error_load": "Failed to load file. It may not be a scene data file.",
+        "error_corrupted_header": "The file header is corrupted.",
         "info_upload": "Please upload a scene data (.png).",
         "scene_info_title": "Scene Information",
         "scene_title": "Title",
@@ -356,7 +358,10 @@ def set_character_image(chara, name="", scene_title=""):
     """
     header = getattr(chara, "header", b"")
     if isinstance(header, bytes):
-        header = header.decode("utf-8")
+        try:
+            header = header.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError("corrupted_header")
 
     # 接尾辞なしの GameParameter と GameInfo を削除
     for block_name in ["GameParameter", "GameInfo"]:
@@ -445,7 +450,10 @@ def analyze_scene(hs):
             if chara:
                 header = getattr(chara, "header", "Unknown")
                 if isinstance(header, bytes):
-                    header = header.decode("utf-8")
+                    try:
+                        header = header.decode("utf-8")
+                    except UnicodeDecodeError:
+                        header = "(corrupted)"
 
                 # 名前を取得
                 name = "Unknown"
@@ -602,7 +610,11 @@ if uploaded_file is not None:
                 col3.write(anime_display if anime_display else "-")
                 # headerに応じた画像をセットしてからバイト化
                 chara = c["data"]
-                set_character_image(chara, c["name"], hs.title or "")
+                try:
+                    set_character_image(chara, c["name"], hs.title or "")
+                except ValueError:
+                    col4.error(get_text("error_corrupted_header", lang))
+                    continue
                 chara_bytes = bytes(chara)
                 filename = f"{c['name'] or 'character'}_{i}.png"
                 col4.download_button(

--- a/pages/ec-to-kk.py
+++ b/pages/ec-to-kk.py
@@ -40,6 +40,7 @@ TRANSLATIONS = {
 """,
         "file_uploader": "コイカツ/コイカツサンシャイン/エモクリのキャラクター画像を選択",
         "error_load": "ファイルの読み込みに失敗しました。未対応のファイルです。",
+        "error_corrupted_header": "ファイルのヘッダが破損しています。別のファイルを試してください。",
         "error_unsupported": "このヘッダのファイルには対応していません:",
         "header_label": "ヘッダ:",
         "name_label": "キャラクター名:",
@@ -83,6 +84,7 @@ A tool to convert characters between Koikatsu ↔ Koikatsu Sunshine ↔ Emotion 
 """,
         "file_uploader": "Select a character image (Koikatsu / Koikatsu Sunshine / Emotion Creators)",
         "error_load": "Failed to load file. Unsupported file format.",
+        "error_corrupted_header": "The file header is corrupted. Please try a different file.",
         "error_unsupported": "This header file is not supported:",
         "header_label": "Header:",
         "name_label": "Character name:",
@@ -673,7 +675,11 @@ def main():
         st.error(get_text("error_load", lang), icon="🚨")
         st.stop()
 
-    header = header_info.header.decode("utf-8")
+    try:
+        header = header_info.header.decode("utf-8")
+    except UnicodeDecodeError:
+        st.error(get_text("error_corrupted_header", lang), icon="🚨")
+        st.stop()
     source_type_map = {
         "【EroMakeChara】": "EC",
         "【KoiKatuChara】": "KK",

--- a/pages/sv-hc-converter.py
+++ b/pages/sv-hc-converter.py
@@ -38,6 +38,7 @@ TRANSLATIONS = {
 """,
         "file_uploader": "サマすく/ハニカム/アイコミのキャラ画像を選択",
         "error_load": "ファイルの読み込みに失敗しました。未対応のファイルです。",
+        "error_corrupted_header": "ファイルのヘッダが破損しています。別のファイルを試してください。",
         "success_load": "正常にデータを読み込めました。",
         "error_unsupported": "このヘッダのファイルには対応していません:",
         "file_is_hc": "このファイルは **ハニカム** のキャラデータです。",
@@ -79,6 +80,7 @@ This tool allows you to convert character data between Honey Come, Summer Vacati
 """,
         "file_uploader": "Select a character image (Summer Vacation Scramble / Honey Come / Aicomi)",
         "error_load": "Failed to load file. Unsupported file format.",
+        "error_corrupted_header": "The file header is corrupted. Please try a different file.",
         "success_load": "Data loaded successfully.",
         "error_unsupported": "This header file is not supported:",
         "file_is_hc": "This file is a **Honey Come** character.",
@@ -667,7 +669,11 @@ if file is not None:
 
     st.success(get_text("success_load", lang), icon="✅")
 
-    header = kch.header.decode("utf-8")
+    try:
+        header = kch.header.decode("utf-8")
+    except UnicodeDecodeError:
+        st.error(get_text("error_corrupted_header", lang), icon="🚨")
+        st.stop()
 
     if header not in ["【HCChara】", "【SVChara】", "【ACChara】"]:
         st.error(f"{get_text('error_unsupported', lang)} {header}", icon="🚨")


### PR DESCRIPTION
## Summary

#47 はおそらくプログラム実行でOOMからのタスクキルによってヘルスチェックが失敗しているものと思われる。

そこで、容易にRAMを食ってしまいそうなパターンを調査したところ、カリグラファーのドットモードにて正常とされる入力範囲内でも4GiBほど食ってしまうパターンがあった。これを事前に止められるようにした。

これが完全解決させるわけではない(普通にでかいテクスチャを含んだキャラデータとかで2GiBとかを食う場合はどうしようもない)が、ちょっとはマシになるはず。

## ためしたこと

とても複雑な漢字50個

```
鬱璽鑿驫麤躊躇薔薇檸檬鷹鷲鱗鱶髑髏饕餮蠱蠍讖讐籤纏轟顰蹙贔屓龜龍靈體變邊藝聲鐵鑑覽驟霧霞麒麟鳳凰魑魅
```

を投入し、psutilでRAM使用量をみた。

### ドットモード計測結果

| 条件 | 文字 | ピークRSS | 生成平面数 | scene bytes | 時間 |
|---|---:|---:|---:|---:|---:|
| `res=100 / AA off / 結合 on` | 複雑漢字50 | 230.5 MB | 6,673 | 4.08 MB | 3.3s |
| `res=100 / AA off / 結合 off` | 複雑漢字50 | 844.2 MB | 70,253 | 42.16 MB | 27.7s |
| `res=200 / AA on / 結合 off` | 複雑漢字50 | **4,096.9 MB** | 374,849 | 233.0 MB | 152.4s |

### メッシュモード計測結果

| 条件 | 文字 | 三角形/平面数 | ピークRSS | 時間 |
|---|---:|---:|---:|---:|
| mesh default | simple 10 | 2,790 | 255 MB | 16.7s |
| mesh default | 複雑漢字10 | 8,253 | 360 MB | 49.5s |
| mesh default | 複雑漢字25 | 20,995 | 674 MB | 124.6s |
| mesh default | 複雑漢字50 | 39,695 | 1,137 MB | 232.5s |
| mesh dense | 複雑漢字10 | 14,414 | 497 MB | 90.7s |
| mesh outline | 複雑漢字10 | 24,104 | 726 MB | 159.8s |

[Streamlit CloudのRAM上限は2.7GiB](docs.streamlit.io/deploy/streamlit-community-cloud/manage-your-app#app-resources-and-limits)らしい。そこでハードリミットを平面数60kとしてみた。

## そのほか

- ファイルが壊れているとき、ヘッダの読み込みにて `UnicodeDecodeError` をハンドリングできていなかったのを修正した。
